### PR TITLE
Add tests from main to release-0.2 branch - mod

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -70,3 +70,17 @@ jobs:
     targets:
       - rhel-8-aarch64
       - rhel-8-x86_64
+
+  - job: tests
+    trigger: pull_request
+    identifier: "unit/centos-stream"
+    targets:
+      - centos-stream-9-x86_64
+      - centos-stream-8-x86_64
+    labels:
+      - unit
+    tf_extra_params:
+      environments:
+        - artifacts:
+            - type: repository-file
+              id: https://copr.fedorainfracloud.org/coprs/g/yggdrasil/latest/repo/centos-stream-$releasever/group_yggdrasil-latest-centos-stream-$releasever.repo

--- a/.sourcery.yaml
+++ b/.sourcery.yaml
@@ -1,0 +1,5 @@
+rule_settings:
+  enable: [default]
+  disable:
+    - no-loop-in-tests
+    - no-conditionals-in-tests

--- a/integration-tests/conftest.py
+++ b/integration-tests/conftest.py
@@ -1,0 +1,41 @@
+import pytest
+import subprocess
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def pytest_configure():
+    """Setting the name of service available on the system with rhc installed
+    Name of the service in upstream package is 'yggdrasil'
+    and downstream is 'rhcd'
+    """
+    proc = subprocess.run(
+        ["systemctl", "status", "yggdrasil"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+    if "Unit yggdrasil.service could not be found" in proc.stderr:
+        pytest.service_name = "rhcd"
+    else:
+        pytest.service_name = "yggdrasil"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def install_katello_rpm(test_config):
+    if "satellite" in test_config.environment:
+        # install katello rpm before register system against Satellite
+        satellite_hostname = test_config.get("candlepin", "host")
+        cmd = [
+            "rpm",
+            "-Uvh",
+            "http://%s/pub/katello-ca-consumer-latest.noarch.rpm" % satellite_hostname,
+        ]
+        subprocess.check_call(cmd)
+        logger.info("installing the katello rpm")
+    yield
+    if "satellite" in test_config.environment:
+        cmd = "rpm -qa 'katello-ca-consumer*' | xargs rpm -e"
+        subprocess.check_call(cmd, shell=True)
+        logger.info("removing the katello rpm")

--- a/integration-tests/requirements.txt
+++ b/integration-tests/requirements.txt
@@ -1,0 +1,3 @@
+git+https://github.com/RedHatInsights/pytest-client-tools@main
+pyyaml
+sh

--- a/integration-tests/test_connect.py
+++ b/integration-tests/test_connect.py
@@ -1,0 +1,203 @@
+"""
+This Python module contains integration tests for rhc.
+It uses pytest-client-tools Python module.More information about this
+module could be found: https://github.com/RedHatInsights/pytest-client-tools/
+"""
+
+import contextlib
+import time
+import logging
+import pytest
+from datetime import datetime
+import sh
+
+from utils import (
+    yggdrasil_service_is_active,
+    prepare_args_for_connect,
+    check_yggdrasil_journalctl_logs,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.parametrize(
+    "auth, output_format",
+    [
+        ("basic", None),
+        ("basic", "json"),
+        ("activation-key", None),
+        ("activation-key", "json"),
+    ]
+)
+def test_connect(external_candlepin, rhc, test_config, auth, output_format):
+    """
+     Test if RHC can connect to CRC using basic auth and activation key,
+     Also verify that yggdrasil/rhcd service is in active state afterward.
+     Two variants of output format is considered.
+       * Default text output
+       * Machine readable output (JSON document)
+     """
+    # rhc+satellite does not support basic auth for now
+    # refer: https://issues.redhat.com/browse/RHEL-53436
+    if "satellite" in test_config.environment and auth == "basic":
+        pytest.skip("rhc+satellite only support activation key registration now")
+    with contextlib.suppress(Exception):
+        rhc.disconnect()
+    command_args = prepare_args_for_connect(test_config, auth=auth, output_format=output_format)
+    command = ["connect"] + command_args
+    result = rhc.run(*command)
+    assert rhc.is_registered
+    assert yggdrasil_service_is_active()
+
+    if output_format is None:
+        assert "Connected to Red Hat Subscription Management" in result.stdout
+        assert "Connected to Red Hat Insights" in result.stdout
+    elif output_format == "json":
+        pass
+        # TODO: parse result.stdout, when CCT-1191 is fixed. It is not possible now, because
+        #       "rhc connect --format json" prints JSON document to stderr (not stdout)
+        # json_output = json.loads(result.stdout)
+        # assert json_output["rhsm_connected"] is True
+
+    if pytest.service_name == "rhcd":
+        if output_format is None:
+            assert "Activated the Remote Host Configuration daemon" in result.stdout
+        elif output_format == "json":
+            pass
+            # TODO: parse result.stdout, when CCT-1191 is fixed
+    else:
+        if output_format is None:
+            assert "Activated the yggdrasil service" in result.stdout
+        elif output_format == "json":
+            pass
+            # TODO: parse result.stdout, when CCT-1191 is fixed
+
+    if output_format is None:
+        assert "Successfully connected to Red Hat!" in result.stdout
+    elif output_format == "json":
+        pass
+        # TODO: parse result.stdout, when CCT-1191 is fixed
+
+
+@pytest.mark.parametrize(
+    "credentials,server",
+    [
+        (  # username and password: valid, server: invalid
+            {"username": "candlepin.username", "password": "candlepin.password"},
+            "http://non-existent.server",
+        ),
+        (  # organization and activation-key: valid, server: invalid
+            {
+                "organization": "candlepin.org",
+                "activation-key": "candlepin.activation_keys",
+            },
+            "http://non-existent.server",
+        ),
+        (  # password and server: valid, username: invalid
+            {"username": "non-existent-user", "password": "candlepin.password"},
+            None,
+        ),
+        (  # activation-key and server: valid, organization: invalid
+            {
+                "organization": "non-existent-org",
+                "activation-key": "candlepin.activation_keys",
+            },
+            None,
+        ),
+        (  # username and server: valid, password: invalid
+            {"username": "candlepin.username", "password": "xpto123"},
+            None,
+        ),
+        (  # organization and server: valid, activation-key: invalid
+            {"organization": "candlepin.org", "activation-key": "xpto123"},
+            None,
+        ),
+        (  # invalid combination of parameters (username & activation-key)
+            {
+                "username": "candlepin.username",
+                "activation-key": "candlepin.activation_keys",
+            },
+            None,
+        ),
+        (  # invalid combination of parameters (password & activation-key)
+            {
+                "activation-key": "candlepin.activation_keys",
+                "password": "candlepin.password",
+            },
+            None,
+        ),
+        (  # invalid combination of parameters (activation-key without organization)
+                {
+                    "activation-key": "candlepin.activation_keys",
+                },
+                None,
+        ),
+    ],
+)
+def test_connect_wrong_parameters(
+    external_candlepin, rhc, test_config, credentials, server
+):
+    """Test if RHC handles invalid credentials properly"""
+    # An attempt to bring system in disconnected state in case it is not.
+    with contextlib.suppress(Exception):
+        rhc.disconnect()
+    command_args = prepare_args_for_connect(
+        test_config, credentials=credentials, server=server
+    )
+    command = ["connect"] + command_args
+    result = rhc.run(*command, check=False)
+    assert result.returncode != 0
+    assert not yggdrasil_service_is_active()
+
+
+@pytest.mark.skip("Test cannot be run due to unresolved issues CCT-696")
+@pytest.mark.parametrize("auth", ["basic", "activation-key"])
+def test_rhc_worker_playbook_install_after_rhc_connect(
+    external_candlepin, rhc, test_config, auth
+):
+    """
+    Test that rhc-worker-playbook is installed after rhc-connect,
+    Also log the total time taken to install the package
+        test_steps:
+            1- run 'rhc connect'
+            2- monitor yggdrasil/rhcd logs to see when package-manager-worker installs 'rhc-worker-playbook'
+            3- validate rhc-worker-playbook is installed
+    """
+    with contextlib.suppress(Exception):
+        sh.yum("remove", "rhc-worker-playbook", "-y")
+
+    success_message = "Registered rhc-worker-playbook"
+    with contextlib.suppress(Exception):
+        rhc.disconnect()
+
+    start_date_time = datetime.now().strftime(
+        "%Y-%m-%d %H:%M:%S"
+    )  # current date and time for observing yggdrasil/rhcd logs
+    command_args = prepare_args_for_connect(test_config, auth=auth)
+    command = ["connect"] + command_args
+    rhc.run(*command, check=False)
+    assert rhc.is_registered
+
+    # Verifying if rhc-worker-playbook was installed successfully
+    t_end = time.time() + 60 * 5  # maximum time to wait for installation
+    while time.time() < t_end:
+        installed_status = check_yggdrasil_journalctl_logs(
+            str_to_check=success_message,
+            since_datetime=start_date_time,
+            must_exist_in_log=True,
+        )
+        if installed_status:
+            break
+    assert (
+        installed_status
+    ), "rhc connect is expected to install rhc_worker_playbook package"
+
+    total_runtime = datetime.now() - datetime.strptime(
+        start_date_time, "%Y-%m-%d %H:%M:%S"
+    )
+    pkg_version = sh.rpm("-qa", "rhc-worker-playbook")
+    logger.info(f"successfully installed rhc_worker_playbook package {pkg_version}")
+    logger.info(
+        f"time taken to start yggdrasil/rhcd service and install "
+        f"rhc_worker_playbook : {total_runtime} s"
+    )

--- a/integration-tests/test_disconnect.py
+++ b/integration-tests/test_disconnect.py
@@ -1,0 +1,91 @@
+"""
+This Python module contains integration tests for rhc.
+It uses pytest-client-tools Python module. More information about
+this module could be found: https://github.com/RedHatInsights/pytest-client-tools/
+"""
+
+import pytest
+
+from utils import yggdrasil_service_is_active
+
+
+def test_rhc_disconnect(external_candlepin, rhc, test_config):
+    """Verify that RHC disconnect command disconnects host from server
+    and deactivates yggdrasil service.
+    test_steps:
+        1- run rhc connect
+        2- run rhc disconnect
+    expected_output:
+        1- Assert exit code 0
+        2- Validate that these string are present in the stdout:
+            "Deactivated the yggdrasil service",
+            "Disconnected from Red Hat Insights",
+            "Disconnected from Red Hat Subscription Management"
+    """
+    # Connect first to perform disconnect operation
+    rhc.connect(
+        username=test_config.get("candlepin.username"),
+        password=test_config.get("candlepin.password"),
+    )
+    assert rhc.is_registered
+    assert yggdrasil_service_is_active()
+    disconnect_result = rhc.run("disconnect", check=False)
+    assert disconnect_result.returncode == 0
+    assert not rhc.is_registered
+    assert not yggdrasil_service_is_active()
+    if pytest.service_name == "rhcd":
+        assert (
+            "Deactivated the Remote Host Configuration daemon"
+            in disconnect_result.stdout
+        )
+    else:
+        assert "Deactivated the yggdrasil service" in disconnect_result.stdout
+    assert "Disconnected from Red Hat Insights" in disconnect_result.stdout
+    assert (
+        "Disconnected from Red Hat Subscription Management" in disconnect_result.stdout
+    )
+
+
+@pytest.mark.skip(
+    reason="Test cannot be run due to unresolved issue https://issues.redhat.com/browse/CCT-525"
+)
+def test_disconnect_when_already_disconnected(rhc):
+    """Test RHC disconnect command when the host is already
+    disconnected from CRC
+    test_steps:
+      # rhc disconnect
+    expected_output:
+      1. validate that these string are present in the stdout:
+            "Deactivated the yggdrasil/rhcd service",
+            "Cannot disconnect from Red Hat Subscription Management",
+            "insights  cannot disconnect from Red Hat Insights",
+            "rhsm      cannot disconnect from Red Hat Subscription Management: "
+            "warning: the system is already unregistered",
+    """
+    # one attempt to disconnect to ensure system is already disconnected
+    rhc.run("disconnect", check=False)
+    # second attempt to disconnect already disconnected system
+    disconnect_result = rhc.run("disconnect", check=False)
+    assert disconnect_result.returncode == 1
+    assert not rhc.is_registered
+    if pytest.service_name == "rhcd":
+        assert (
+            "Deactivated the Remote Host Configuration daemon"
+            in disconnect_result.stdout
+        )
+    else:
+        assert "Deactivated the yggdrasil service" in disconnect_result.stdout
+    assert "Cannot disconnect from Red Hat Insights" in disconnect_result.stdout
+    assert (
+        "Cannot disconnect from Red Hat Subscription Management"
+        in disconnect_result.stdout
+    )
+    assert (
+        "rhsm      cannot disconnect from Red Hat Subscription Management:"
+        in disconnect_result.stdout
+    )
+    assert "warning: the system is already unregistered" in disconnect_result.stdout
+    assert (
+        "ERROR  insights  cannot disconnect from Red Hat Insights"
+        in disconnect_result.stdout
+    )

--- a/integration-tests/test_e2e.py
+++ b/integration-tests/test_e2e.py
@@ -1,0 +1,45 @@
+"""
+This Python module contains integration tests for rhc.
+It uses pytest-client-tools Python module.More information about this
+module could be found: https://github.com/RedHatInsights/pytest-client-tools/
+"""
+
+import contextlib
+import pytest
+import time
+from utils import (
+    yggdrasil_service_is_active,
+    prepare_args_for_connect,
+)
+
+
+@pytest.mark.skip("Test cannot be run due to unresolved issues CCT-862 and CCT-696")
+@pytest.mark.parametrize("auth", ["activation-key", "basic"])
+def test_rhc_client_connect_e2e(rhc, test_config, auth, external_inventory, subman):
+    """
+    Test RHC Client connect e2e using basic auth and activation key
+    test_steps:
+        1. Run RHC client connect
+    expected_results:
+        1. The rhcd service is running and active
+        2. A new host is created in Inventory
+        3. The rhc_client_id in system profile matches the subman-id
+    """
+    with contextlib.suppress(Exception):
+        rhc.disconnect()
+    command_args = prepare_args_for_connect(test_config, auth=auth)
+    command = ["connect"] + command_args
+    rhc.run(*command)
+    assert rhc.is_registered
+    assert yggdrasil_service_is_active()
+    timeout = 60.0
+    start = time.time()
+    while True:
+        system_profile = external_inventory.this_system_profile()
+        if "rhc_client_id" in system_profile:
+            assert system_profile["rhc_client_id"] == str(subman.uuid)
+            break
+        current = time.time()
+        if current - start > timeout:
+            raise ValueError("timeout")
+        time.sleep(10)

--- a/integration-tests/test_man_page.py
+++ b/integration-tests/test_man_page.py
@@ -1,0 +1,67 @@
+"""
+This Python module contains integration tests for rhc.
+It uses pytest-client-tools Python module. More information about
+this module could be found: https://github.com/RedHatInsights/pytest-client-tools/
+"""
+
+import subprocess
+import pytest
+
+
+def test_man_page_synopsis():
+    """This test verifies format of man page"""
+    command_op = subprocess.check_output(["man", "rhc"]).decode("utf-8")
+    assert (
+        "rhc [GLOBAL OPTIONS] command [COMMAND OPTIONS] " "[ARGUMENTS...]"
+    ) in command_op
+
+
+def test_man_page_global_options():
+    """Test verifies global option are present in man page"""
+    command_op = subprocess.check_output(["man", "rhc"]).decode("utf-8")
+    assert "--help, -h" in command_op
+    assert "--no-color" in command_op
+    assert "--version, -v" in command_op
+
+
+@pytest.mark.parametrize("command", ["connect", "disconnect", "status", "help"])
+def test_man_page_commands(command):
+    """Test verifies if man page displays existing commands"""
+    command_op = subprocess.check_output(["man", "rhc"]).decode("utf-8")
+    assert command in command_op
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        ["--activation-key", "-a"],
+        ["--organization", "-o"],
+        ["--password", "-p"],
+        ["--username", "-u"],
+        ["--enable-feature", "-e"],
+        ["--disable-feature", "-d"],
+        ["--content-template", "-c"],
+    ],
+)
+def test_man_page_connect_options(options):
+    """
+    Test verifies if man page displays existing options for commands
+    """
+    command_op = subprocess.check_output(["man", "rhc"]).decode("utf-8")
+    for option in options:
+        assert option in command_op
+
+@pytest.mark.parametrize(
+    "feature_id",
+    [
+        "content",
+        "analytics",
+        "remote-management",
+    ]
+)
+def test_man_page_feature_ids(feature_id):
+    """
+    Test verifies if man page contains IDs of features
+    """
+    command_op = subprocess.check_output(["man", "rhc"]).decode("utf-8")
+    assert feature_id in command_op

--- a/integration-tests/test_status.py
+++ b/integration-tests/test_status.py
@@ -1,0 +1,131 @@
+"""
+This Python module contains integration tests for rhc. It uses pytest-client-tools Python module.
+More information about this module could be found: https://github.com/RedHatInsights/pytest-client-tools/
+"""
+
+import pytest
+import json
+from pytest_client_tools import util
+from utils import yggdrasil_service_is_active
+
+
+def test_status_connected(external_candlepin, rhc, test_config):
+    """Test RHC Status command when the host is connected.
+    test_steps:
+        1- rhc connect
+        2- rhc status
+    expected_output:
+        1- Validate following strings in status command output
+            "Connected to Red Hat Subscription Management"
+            "Connected to Red Hat Insights"
+            "The yggdrasil/rhcd service is active"
+    """
+    rhc.connect(
+        username=test_config.get("candlepin.username"),
+        password=test_config.get("candlepin.password"),
+    )
+    assert yggdrasil_service_is_active()
+    status_result = rhc.run("status", check=False)
+    assert status_result.returncode == 0
+    assert "Connected to Red Hat Subscription Management" in status_result.stdout
+    assert "Connected to Red Hat Insights" in status_result.stdout
+    if pytest.service_name == "rhcd":
+        assert "The Remote Host Configuration daemon is active" in status_result.stdout
+    else:
+        assert "The yggdrasil service is active" in status_result.stdout
+
+
+def test_status_connected_format_json(external_candlepin, rhc, test_config):
+    """
+    Test 'rhc status --format json' command, when host is connected
+    test_steps:
+        1 - rhc connect
+        2 - rhc status
+    expected_output:
+        1 - Validate that output is valid JSON document
+        2 - Validate that JSON document contains expected data
+    """
+    rhc.connect(
+        username=test_config.get("candlepin.username"),
+        password=test_config.get("candlepin.password")
+    )
+    status_result = rhc.run("status", "--format", "json", check=False)
+    assert status_result.returncode == 0
+    status_json = json.loads(status_result.stdout)
+    assert "hostname" in status_json
+    assert "rhsm_connected" in status_json
+    assert type(status_json["rhsm_connected"]) == bool
+    assert "insights_connected" in status_json
+    assert type(status_json["insights_connected"]) == bool
+    if pytest.service_name == "rhcd":
+        assert "rhcd_running" in status_json
+        assert type(status_json["rhcd_running"]) == bool
+    else:
+        assert "yggdrasil_running" in status_json
+        assert type(status_json["yggdrasil_running"]) == bool
+
+
+def test_status_disconnected(rhc):
+    """Test RHC Status command when the host is disconnected.
+    Ref: https://issues.redhat.com/browse/CCT-525
+    test_steps:
+        1- rhc disconnect
+        2- rhc status
+    expected_output:
+        1- Validate following strings in status command output
+            "Not connected to Red Hat Subscription Management"
+            "Not connected to Red Hat Insights"
+            "The yggdrasil/rhc service is inactive"
+    """
+    # 'rhc disconnect' to ensure system is already disconnected
+    rhc.run("disconnect", check=False)
+    status_result = rhc.run("status", check=False)
+    assert status_result.returncode != 0
+    assert "Not connected to Red Hat Subscription Management" in status_result.stdout
+    assert "Not connected to Red Hat Insights" in status_result.stdout
+    if pytest.service_name == "rhcd":
+        assert "The Remote Host Configuration daemon is active" in status_result.stdout
+    else:
+        assert "The yggdrasil service is inactive" in status_result.stdout
+
+
+@pytest.mark.skipif(
+    pytest.service_name != "rhcd",
+    reason="This test only supports restart of rhcd and not yggdrasil",
+)
+def test_rhcd_service_restart(external_candlepin, rhc, test_config):
+    """
+    Test rhcd service can be restarted on connected and  not on disconnected system.
+    test_steps:
+        1- disconnect the system
+        2- restart rhcd service via systemctl
+        3- run rhc connect
+        4- restart rhcd service via systemctl
+    expected_results:
+        1- rhcd  should be restarted successfully on connected system
+    """
+
+    # 'rhc disconnect' to ensure system is already disconnected
+    rhc.run("disconnect", check=False)
+    util.logged_run("systemctl status rhcd --no-pager".split())
+    try:
+
+        util.logged_run("systemctl restart rhcd".split())
+        assert not yggdrasil_service_is_active()
+    except AssertionError as exc:
+        # for debugging lets check current state of rhcd service
+        util.logged_run("systemctl status rhcd --no-pager".split())
+        raise exc
+
+    # test rhcd service restart on a connected system
+    rhc.connect(
+        username=test_config.get("candlepin.username"),
+        password=test_config.get("candlepin.password"),
+    )
+    assert rhc.is_registered
+    try:
+        util.logged_run("systemctl restart rhcd".split())
+        assert yggdrasil_service_is_active()
+    except AssertionError as exc:
+        util.logged_run("systemctl status rhcd --no-pager".split())
+        raise exc

--- a/integration-tests/test_version.py
+++ b/integration-tests/test_version.py
@@ -1,0 +1,3 @@
+def test_version(rhc):
+    proc = rhc.run("--version")
+    assert "rhc version " in proc.stdout

--- a/integration-tests/utils/__init__.py
+++ b/integration-tests/utils/__init__.py
@@ -1,0 +1,82 @@
+import pytest
+import sh
+
+
+def yggdrasil_service_is_active():
+    """Method to verify if yggdrasil/rhcd is in active/inactive state
+    :return: True if yggdrasil/rhcd in active state else False
+    Note: upstream name of service is yggdrasil and downstream is rhcd
+    """
+    try:
+        stdout = sh.systemctl(f"is-active {pytest.service_name}".split()).strip()
+        return stdout == "active"
+    except sh.ErrorReturnCode_3:
+        return False
+
+
+def check_yggdrasil_journalctl_logs(
+    str_to_check, since_datetime=None, must_exist_in_log=True
+):
+    """This method helps in verifying strings in journalctl logs
+    :param str_to_check: string to be searched in logs
+    :param since_datetime: start time for logs
+    :param must_exist_in_log: True if str_to_check should exist in log else false
+    :return: True/False
+    Note: upstream name of service is yggdrasil and downstream is rhcd
+    """
+    if since_datetime:
+        logs = sh.journalctl("-u", pytest.service_name, "--since", since_datetime)
+    else:
+        logs = sh.journalctl("-u", pytest.service_name)
+
+    if must_exist_in_log:
+        return str_to_check in logs
+    else:
+        return str_to_check not in logs
+
+
+def prepare_args_for_connect(
+    test_config, auth: str = None, credentials: dict = None, output_format: str = None, server: str = None
+):
+    """Method to create arguments to be passed in 'rhc connect' command
+    This method expects either auth type or custom credentials
+    """
+    args = []
+    if credentials:
+        for k, v in credentials.items():
+            try:
+                value = test_config.get(v)
+                value = value[0] if isinstance(value, list) else value
+            except KeyError:
+                value = v
+            if value:
+                args.extend([f"--{k}", value])
+
+    elif auth:
+        if auth == "basic":
+            args.extend(
+                [
+                    "--username",
+                    test_config.get("candlepin.username"),
+                    "--password",
+                    test_config.get("candlepin.password"),
+                ]
+            )
+
+        elif auth == "activation-key":
+            args.extend(
+                [
+                    "--activation-key",
+                    test_config.get("candlepin.activation_keys")[0],
+                    "--organization",
+                    test_config.get("candlepin.org"),
+                ]
+            )
+
+    if output_format:
+        args.extend(["--format", output_format])
+
+    if server:
+        args.extend(["--server", server])
+
+    return args

--- a/systemtest/copr-setup.sh
+++ b/systemtest/copr-setup.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/bash -eux
+dnf install -y dnf-plugins-core
+
+#Determine the repo needed from copr
+#Available repositories: 'centos-stream-8-x86_64', 'rhel-8-x86_64',
+# 'centos-stream-9-x86_64', 'rhel-9-x86_64', 'fedora-40-x86_64',
+# 'fedora-39-x86_64', 'fedora-rawhide-x86_64'
+source /etc/os-release
+
+VERSION_MAJOR=$(echo ${VERSION_ID} | cut -d '.' -f 1)
+
+if [[ "$ID" == "centos" ]] || { [[ "$ID" == "rhel" ]] && [[ "$VERSION_MAJOR" == "10" ]]; }; then
+  ID='centos-stream'
+fi
+
+COPR_REPO="${ID}-${VERSION_MAJOR}-$(uname -m)"
+
+#get yggdrasil
+dnf copr -y enable @yggdrasil/latest ${COPR_REPO}
+dnf install -y yggdrasil yggdrasil-worker-package-manager --disablerepo=* --enablerepo=*yggdrasil*
+
+#Install rhc for dependencies
+dnf install -y rhc
+
+# These PR packit builds have an older version number for some reason than the released...
+dnf remove -y --noautoremove rhc
+dnf copr -y enable packit/RedHatInsights-rhc-${ghprbPullId} ${COPR_REPO}
+dnf install -y rhc --disablerepo=* --enablerepo=*rhc*

--- a/systemtest/plans/main.fmf
+++ b/systemtest/plans/main.fmf
@@ -1,0 +1,6 @@
+summary: rhc test suite
+discover:
+    how: fmf
+
+execute:
+    how: tmt

--- a/systemtest/tests/integration/main.fmf
+++ b/systemtest/tests/integration/main.fmf
@@ -1,0 +1,3 @@
+summary: Runs tmt tests
+test: ./test.sh
+duration: 1h

--- a/systemtest/tests/integration/test.sh
+++ b/systemtest/tests/integration/test.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -ux
+
+# get to project root
+cd ../../../
+
+# Check for bootc/image-mode deployments which should not run dnf
+if ! command -v bootc >/dev/null || bootc status | grep -q 'type: null'; then
+  # Check for GitHub pull request ID and install build if needed.
+  # This is for the downstream PR jobs.
+  [ -z "${ghprbPullId+x}" ] || ./systemtest/copr-setup.sh
+
+  dnf --setopt install_weak_deps=False install -y \
+    podman git-core python3-pip python3-pytest logrotate
+fi
+
+python3 -m venv venv
+# shellcheck disable=SC1091
+. venv/bin/activate
+pip install --upgrade pip
+pip install -r integration-tests/requirements.txt
+
+if [ -n "${SETTINGS_URL+x}" ] && curl -I "$SETTINGS_URL" > /dev/null 2>&1; then
+  [ -f ./settings.toml ] && mv ./settings.toml.bak
+  curl "$SETTINGS_URL" -o ./settings.toml
+fi
+
+pytest --junit-xml=./junit.xml -v integration-tests
+retval=$?
+
+if [ -d "$TMT_PLAN_DATA" ]; then
+  cp ./junit.xml "$TMT_PLAN_DATA/junit.xml"
+  cp -r ./artifacts "$TMT_PLAN_DATA/"
+fi
+
+exit $retval


### PR DESCRIPTION
## Summary by Sourcery

Add integration tests for RHC (Remote Host Configuration) client, covering various scenarios like connect, disconnect, status, and version checks

New Features:
- Added comprehensive integration tests for RHC client functionality

CI:
- Added Packit configuration for CentOS Stream and RHEL test targets

Tests:
- Added test suite for RHC client covering connect, disconnect, status, and version commands
- Implemented parametrized tests for different authentication methods
- Added man page validation tests
- Created utility functions for test setup and service checks

Chores:
- Added configuration files for test infrastructure
- Added requirements file for test dependencies
- Added Sourcery configuration
- Created system test setup scripts